### PR TITLE
fastify-metrics implementation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
         "dotenv": "^16.5.0",
         "fastify": "^5.4.0",
         "fastify-decorators": "^3.16.1",
+        "fastify-metrics": "^12.1.0",
         "google-auth-library": "^9.15.1",
         "jsonwebtoken": "^9.0.2",
         "prettier": "^3.6.2",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,8 @@ import { registerDB } from './database/client';
 import { UserController } from './modules/user/user.controller';
 import { AuthController } from './modules/auth/auth.controller';
 
+import metricsPlugin from 'fastify-metrics';
+
 export default async function App() {
     const app = Fastify({ logger: true });
 
@@ -26,6 +28,13 @@ export default async function App() {
     // Register decorators
     app.register(bootstrap, {
         controllers: [UserController, AuthController],
+    });
+
+    // fastify-metrics for Prometheus Database
+    await app.register(metricsPlugin, { 
+        endpoint: '/metrics',
+        defaultMetrics: { enabled: true },
+        routeMetrics: { enabled: true},
     });
 
     return app;


### PR DESCRIPTION
This small implementation will be helpful afterwards to store metrics in Prometheus Database

In this PR was done:

    'fastify-metrics' package installation for backend
    Calling function 'register' to store in endpoint '/metrics'.

When backend is running, metrics can be accessed in http://localhost:8000/metrics

<img width="1909" height="986" alt="image" src="https://github.com/user-attachments/assets/8b8baa39-8949-45e4-9684-73f5b108d1c9" />
